### PR TITLE
To create the directory /var/www/dehydrated

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -23,6 +23,11 @@ EOF
   $SENDMAIL $MAILSERVER $MAILSERVERPORT $MAILFILE >/dev/null 2>&1
 }
 
+
+cd /var/www/
+mkdir -p dehydrated
+
+
 cd /shared/letsencrypt 
 cat /config/filestore/files_d/Common_d/lwtunneltbl_d/*domains.txt* > /shared/letsencrypt/domains.txt
 


### PR DESCRIPTION
After an F5 BigIP upgrade, because of the reboot of the system, the /var/ directory is deleted. The dehydrated script needs the directory /var/www/dehydrated/ to do its work, so creating the directory (if it doesn't exist with option -p) will fix the problem after an F5 upgrade without needing to create the directory manually.